### PR TITLE
Dependency: Replaced tunnel-agent with node-tunnel

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const url = require('url');
 const getProxy = require('get-proxy');
 const isurl = require('isurl');
-const tunnelAgent = require('tunnel-agent');
+const tunnel = require('tunnel');
 const urlToOptions = require('url-to-options');
 
 module.exports = (proxy, opts) => {
@@ -27,7 +27,7 @@ module.exports = (proxy, opts) => {
 
 	delete opts.protocol;
 
-	return tunnelAgent[method](Object.assign({
+	return tunnel[method](Object.assign({
 		proxy: {
 			port,
 			host: proxy.hostname,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"get-proxy": "^2.0.0",
 		"isurl": "^1.0.0-alpha5",
-		"tunnel-agent": "^0.6.0",
+		"tunnel": "^0.0.5",
 		"url-to-options": "^1.0.1"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ Proxy URL. If not set, it'll try getting it using [`get-proxy`](https://github.c
 
 Type: `Object`
 
-Besides the options below, you can pass in options allowed in [tunnel-agent](https://github.com/request/tunnel-agent).
+Besides the options below, you can pass in options allowed in [node-tunnel](https://github.com/koichik/node-tunnel).
 
 ##### protocol
 

--- a/test.js
+++ b/test.js
@@ -81,7 +81,7 @@ test('tunnel methods', t => {
 	const httpOverHttpsSpy = sinon.spy();
 	const httpsOverHttpsSpy = sinon.spy();
 	const caw = proxyquire('.', {
-		'tunnel-agent': {
+		tunnel: {
 			httpOverHttp: httpOverHttpSpy,
 			httpsOverHttp: httpsOverHttpSpy,
 			httpOverHttps: httpOverHttpsSpy,


### PR DESCRIPTION
https://github.com/kevva/caw/issues/22

Disclaimer: I did very little due diligence, Just replaced the dependency and ran the test suite.

Save you a click to the failing Travis build:

Node 8 🆗 
Node 6 👌 
Node 4 🚫 

```
/home/travis/build/kevva/caw/node_modules/xo/main.js:115
const {input, flags: opts} = cli;
      ^
SyntaxError: Unexpected token {
```

Could pin the xo version to before this commit: https://github.com/xojs/xo/commit/d1eb47c8984bd0c53d05c7dce4ed7e03b405aa03

Which is: [0.20.3](https://github.com/xojs/xo/releases/tag/v0.20.3)

Which drops node 4 support and gets node 10 support.

Or could drop node 4 support, FYI: test suite runs fine on latest stable node.